### PR TITLE
Use createProxy to allow use of polyfill for ie11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-react-web-component",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "description": "Set up a React App wrapped in a Web Component",
   "main": "dist/index.js",
   "scripts": {

--- a/src/reactComponent/CustomComponent.tsx
+++ b/src/reactComponent/CustomComponent.tsx
@@ -78,7 +78,6 @@ class CustomComponent extends HTMLElement {
     if (shadow !== undefined && !shadow) {
       ReactDOM.render(application, this);
     } else {
-      // We use createProxy to be able to use a polyfill if needed.
       const root = createProxy({ div: undefined });
       ReactDOM.render(<root.div>{application}</root.div>, this);
     }

--- a/src/reactComponent/CustomComponent.tsx
+++ b/src/reactComponent/CustomComponent.tsx
@@ -3,7 +3,7 @@ import '@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js';
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import root from 'react-shadow';
+import { createProxy } from 'react-shadow';
 import { EventProvider } from '../components/EventContext';
 
 let componentAttributes: any;
@@ -78,6 +78,8 @@ class CustomComponent extends HTMLElement {
     if (shadow !== undefined && !shadow) {
       ReactDOM.render(application, this);
     } else {
+      // We use createProxy to be able to use a polyfill if needed.
+      const root = createProxy({ div: undefined });
       ReactDOM.render(<root.div>{application}</root.div>, this);
     }
   }

--- a/templates/js/package.json
+++ b/templates/js/package.json
@@ -12,7 +12,7 @@
     "react-dom": "16.10.2",
     "react-scripts": "3.2.0",
     "style-it": "2.1.4",
-    "create-react-web-component": "2.0.15"
+    "create-react-web-component": "2.0.16"
   },
   "devDependencies": {
     "jest-environment-jsdom-fourteen": "0.1.0",

--- a/templates/ts/package.json
+++ b/templates/ts/package.json
@@ -11,7 +11,7 @@
     "@types/node": "12.7.8",
     "@types/react": "16.9.3",
     "@types/react-dom": "16.9.1",
-    "create-react-web-component": "2.0.15",
+    "create-react-web-component": "2.0.16",
     "react": "16.10.1",
     "react-dom": "16.10.1",
     "react-scripts": "3.1.2",


### PR DESCRIPTION
Fix https://github.com/Silind-Software/create-react-web-component/issues/3

With this pr we can use https://github.com/GoogleChrome/proxy-polyfill .

Then you can use it like this:
```
// import polyfills for ie 11
import 'react-app-polyfill/ie11';
import 'react-app-polyfill/stable';
import 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only';
import 'proxy-polyfill';

import { ReactWebComponent } from 'create-react-web-component';
import {
  componentAttributes,
  componentProperties,
} from './componentProperties';
import App from './App';

ReactWebComponent.setAttributes(App.attributes);
ReactWebComponent.setProperties(App.defaultProps);
ReactWebComponent.render(App, 'trafimage-maps');
```